### PR TITLE
multi-monitor support

### DIFF
--- a/bin/bin/zoom
+++ b/bin/bin/zoom
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 tmpfile=$(mktemp /tmp/shotscreen.XXXXXXXX.png)
-trap "rm $tmpfile" 0 HUP INT QUIT ILL ABRT KILL SEGV TERM CHLD STOP TSTP
+trap "rm -f $tmpfile" 0 HUP INT QUIT ILL ABRT KILL SEGV TERM STOP TSTP
 
 # Take a screenshot
 maim -u -m 1 $tmpfile

--- a/bin/bin/zoom
+++ b/bin/bin/zoom
@@ -1,10 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
+
 tmpfile=$(mktemp /tmp/shotscreen.XXXXXXXX.png)
+trap "rm $tmpfile" 0 HUP INT QUIT ILL ABRT KILL SEGV TERM CHLD STOP TSTP
 
 # Take a screenshot
 maim -u -m 1 $tmpfile
 
-# Open it in fullscreen
-sxiv -bfN shotscreen $tmpfile
-
-rm "$tmpfile"
+# Open it in fullscreen (press q to quit)
+sxiv -bfZN shotscreen $tmpfile


### PR DESCRIPTION
Added (slightly better) support for multiple monitors. When `sxiv` goes full-screen, it is on a per-_monitor_ basis. Adding `-Z` ensures that if you're on the top-left monitor, this works as expected. Monitors will open full-screen views of the screenshot with the top left pixel of the _monitor_ showing the top left pixel of the screenshot, so you'll see the wrong content on any other monitor.

I also used `trap` to ensure `$tmpfile` is cleaned up regardless of whether the script is terminated. 

Nice observations on speed! `maim` is a _lot_ faster than ImageMagick's `import` and `sxiv` is quite speedy as well. The script will be slightly faster using `/bin/sh` over `/bin/bash` (which would be slightly faster than `/usr/bin/env bash`), and since there are no bashisms, the more basic POSIX shell is functionally identical.